### PR TITLE
Add yolov4 t 3l

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -75,6 +75,7 @@ if (AXERA_TARGET_CHIP MATCHES "ax620a")   # ax620 support
     axera_example (ax_yolov3_tiny           ax_yolov3_tiny_steps.cc)
     axera_example (ax_yolov4                ax_yolov4_steps.cc)
     axera_example (ax_yolov4_tiny           ax_yolov4_tiny_steps.cc)
+    axera_example (ax_yolov4_tiny_3l        ax_yolov4_tiny_3l_steps.cc)
     axera_example (ax_nanodet               ax_nanodet_steps.cc)
     axera_example (ax_paddle_yolov3         ax_paddle_yolov3_steps.cc)
 

--- a/examples/ax_yolov4_tiny_3l_steps.cc
+++ b/examples/ax_yolov4_tiny_3l_steps.cc
@@ -252,7 +252,7 @@ namespace ax
         // 5. get bbox
         yolo::YoloDetectionOutput yolo{};
         std::vector<yolo::TMat> yolo_inputs, yolo_outputs;
-        yolo.init(yolo::YOLOV4_TINY_3L, 0.45, 0.48, 1);
+        yolo.init(yolo::YOLOV4_TINY_3L, 0.35, 0.48, 80);
         yolo_inputs.resize(io_info->nOutputSize);
         yolo_outputs.resize(1);
 
@@ -319,7 +319,7 @@ namespace ax
         fprintf(stdout, "--------------------------------------\n");
         fprintf(stdout, "detection num: %d\n", objects.size());
 
-        det::draw_objects(mat, objects_reverse_letterbox, CLASS_NAMES, "yolov4_tiny_out");
+        det::draw_objects(mat, objects_reverse_letterbox, CLASS_NAMES, "yolov4_tiny_3l_out");
         clear_and_exit();
         return true;
     }

--- a/examples/base/yolo.hpp
+++ b/examples/base/yolo.hpp
@@ -293,7 +293,9 @@ namespace yolo
             m_anchors_scale[1] = 16;
             m_anchors_scale[2] = 8;
 
-            float bias[] = {8, 15, 13, 34, 18, 75, 28, 49, 30, 123, 58, 106, 46, 203, 80, 265, 155, 317};
+            //float bias_official[] = {12, 16, 19, 36, 40, 28,   36, 75, 76, 55, 72, 146,   142, 110, 192, 243, 459, 401};
+            float bias[] = {10, 14, 23, 27, 37, 58, 36, 75, 76, 55, 72, 146, 81, 82, 135, 169, 344, 319};
+
             memcpy(m_biases, bias, sizeof(bias));
 
             m_mask[0] = 6;
@@ -343,10 +345,6 @@ namespace yolo
                             continue;
                         }
 
-                        int biases_index = (int)(m_mask[box + mask_offset]);
-                        const float bias_w = m_biases[biases_index * 2];
-                        const float bias_h = m_biases[biases_index * 2 + 1];
-
                         int class_index = 0;
                         float class_score = -FLT_MAX;
                         for (int k = 5; k < m_num_class + 5; ++k)
@@ -362,6 +360,10 @@ namespace yolo
                         float confidence_1 = 1.0f / ((1.f + std::exp(-feature_ptr[4])) * (1.f + std::exp(-class_score)));
                         if (confidence_1 >= m_confidence_threshold)
                         {
+                            int biases_index = (int)(m_mask[box + mask_offset]);
+                            const float bias_w = m_biases[biases_index * 2];
+                            const float bias_h = m_biases[biases_index * 2 + 1];
+
                             // region box
                             // fprintf(stderr, "%f %f %d \n", class_score, feature_ptr[4], class_index);
                             float bbox_cx = ((float)j + sigmoid(feature_ptr[0])) / (float)w;


### PR DESCRIPTION
1. 官方的yolov4-tiny-3l只提供了[yolov4-tiny.conv.29]预训练weights，这个weights检测基本是错的。
2. yolov4-tiny-3l直接用yolov4-tiny.weights，并且要使用yolov4-tiny.cfg中的anchor, 能够检测出目标，但是理论上有条分支是废掉的。