### PR TITLE
remove scrfd some operator to make runing faster

### DIFF
--- a/examples/base/detection.hpp
+++ b/examples/base/detection.hpp
@@ -187,7 +187,7 @@ namespace detection
                 {
                     int index = i * feat_w + j;
 
-                    float prob = score_blob[q * feat_size + index];
+                    float prob = sigmoid(score_blob[q * feat_size + index]);
 
                     if (prob >= prob_threshold)
                     {


### PR DESCRIPTION
模型来自 [insightface-scrfd](https://github.com/deepinsight/insightface/tree/master/detection/scrfd)
输出onnx模型的时候 需要去掉[scrfd_head.py](https://github.com/deepinsight/insightface/blob/9b6074838977d09648cb7ef825cd412c987c44a8/detection/scrfd/mmdet/models/dense_heads/scrfd_head.py#L335)大概335-337行的操作，如下所示：

将以下操作删掉

```
            cls_score = cls_score.permute(0, 2, 3, 1).reshape(batch_size, -1, self.cls_out_channels).sigmoid()
            bbox_pred = bbox_pred.permute(0, 2, 3, 1).reshape(batch_size, -1, 4)
            kps_pred = kps_pred.permute(0, 2, 3, 1).reshape(batch_size, -1, 10)
```