### PR TITLE
fix: fix read file wrong size

### DIFF
--- a/examples/utilities/file.hpp
+++ b/examples/utilities/file.hpp
@@ -52,7 +52,8 @@ namespace utilities
         fs.seekg(std::ios::beg);
         auto fs_beg = fs.tellg();
 
-        auto file_size = static_cast<size_t>(fs_end - fs_beg);
+        //fstream end-begin has 2 more bytes than actual file size
+        auto file_size = static_cast<size_t>(fs_end - fs_beg - 2);
         auto vector_size = data.size();
 
         data.reserve(vector_size + file_size);


### PR DESCRIPTION
calculating file size with fstream iterator lead to 2 more byte, which cause model file loading fail